### PR TITLE
Add labels to isolatedProjectsIntegTest tasks

### DIFF
--- a/platforms/enterprise/enterprise-logging/build.gradle.kts
+++ b/platforms/enterprise/enterprise-logging/build.gradle.kts
@@ -15,4 +15,5 @@ dependencies {
 }
 tasks.isolatedProjectsIntegTest {
     enabled = false
+    labels.addAll(listOf("@dev-productivity", "a:chore", "in:building-gradle"))
 }

--- a/platforms/enterprise/enterprise-operations/build.gradle.kts
+++ b/platforms/enterprise/enterprise-operations/build.gradle.kts
@@ -14,4 +14,5 @@ dependencies {
 }
 tasks.isolatedProjectsIntegTest {
     enabled = false
+    labels.addAll(listOf("@dev-productivity", "a:chore", "in:building-gradle"))
 }


### PR DESCRIPTION
Add labels to isolatedProjectsIntegTest tasks in build.gradle.kts files.

* Add labels `@dev-productivity`, `a:chore`, and `in:building-gradle` to the `tasks.isolatedProjectsIntegTest` task in `platforms/enterprise/enterprise-logging/build.gradle.kts`
* Add labels `@dev-productivity`, `a:chore`, and `in:building-gradle` to the `tasks.isolatedProjectsIntegTest` task in `platforms/enterprise/enterprise-operations/build.gradle.kts`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/upgraded-umbrella/pull/2?shareId=1fce938f-6bcf-4d39-8fb0-b842fbae7b89).