### PR TITLE
Fix code scanning alert no. 12: Resolving XML external entity in user-controlled data

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyXmlModuleDescriptorParser.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyXmlModuleDescriptorParser.java
@@ -1345,18 +1345,19 @@ public class IvyXmlModuleDescriptorParser extends AbstractModuleDescriptorParser
 
         private static SAXParser newSAXParser(URL schema, InputStream schemaStream)
                 throws ParserConfigurationException, SAXException {
+            SAXParserFactory parserFactory = XmlFactories.newSAXParserFactory();
+            parserFactory.setNamespaceAware(true);
+            parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+
             if (schema == null) {
-                SAXParserFactory parserFactory = XmlFactories.newSAXParserFactory();
                 parserFactory.setValidating(false);
-                parserFactory.setNamespaceAware(true);
                 SAXParser parser = parserFactory.newSAXParser();
                 parser.getXMLReader().setFeature(XML_NAMESPACE_PREFIXES, true);
                 return parser;
             } else {
-                SAXParserFactory parserFactory = XmlFactories.newSAXParserFactory();
                 parserFactory.setValidating(true);
-                parserFactory.setNamespaceAware(true);
-
                 SAXParser parser = parserFactory.newSAXParser();
                 parser.setProperty(JAXP_SCHEMA_LANGUAGE, W3C_XML_SCHEMA);
                 parser.setProperty(JAXP_SCHEMA_SOURCE, schemaStream);


### PR DESCRIPTION
Fixes [https://github.com/akaday/upgraded-umbrella/security/code-scanning/12](https://github.com/akaday/upgraded-umbrella/security/code-scanning/12)

To fix the problem, we need to disable the parsing of external entities in the `SAXParserFactory` used in the `ParserHelper` class. This can be done by setting the appropriate features on the `SAXParserFactory` to prevent XXE attacks.

- Modify the `newSAXParser` method in the `ParserHelper` class to disable external entity resolution.
- Ensure that the `SAXParserFactory` is securely configured regardless of whether a schema is provided or not.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
